### PR TITLE
fix package name

### DIFF
--- a/nim-assimp.babel
+++ b/nim-assimp.babel
@@ -1,6 +1,6 @@
 [Package]
-name = "nim-assimp"
-version = "0.1.1"
+name = "nimassimp"
+version = "0.1.2"
 author = "fowl"
 description = "Assorted wrappers and reusable libraries."
 license = "MIT"


### PR DESCRIPTION
package name with hyphens is not allowed by nimble any more